### PR TITLE
fix: Fix deprecations and bugs

### DIFF
--- a/lua/dap-kotlin/test_query.lua
+++ b/lua/dap-kotlin/test_query.lua
@@ -1,5 +1,3 @@
-local tsquery = require("vim.treesitter.query")
-
 local M = {}
 
 local function sanitised(test_name)
@@ -20,14 +18,14 @@ function M.test_class()
 	local ft = vim.api.nvim_buf_get_option(0, "filetype")
 	assert(ft == "kotlin", "dap-go error: can only debug go files, not " .. ft)
 
-	local test_query = vim.treesitter.parse_query(ft, query)
+	local test_query = vim.treesitter.query.parse(ft, query)
 	assert(test_query, "dap-go error: could not parse test query")
 
 	for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row) do
 		for id, node in pairs(match) do
 			local capture = test_query.captures[id]
 			if capture == "cname" then
-				closest_name = tsquery.get_node_text(node, 0)
+				closest_name = vim.treesitter.get_node_text(node, 0)
 			end
 		end
 	end
@@ -51,7 +49,7 @@ function M.closest_test()
 	local ft = vim.api.nvim_buf_get_option(0, "filetype")
 	assert(ft == "kotlin", "dap-go error: can only debug go files, not " .. ft)
 
-	local test_query = vim.treesitter.parse_query(ft, tests_query)
+	local test_query = vim.treesitter.query.parse(ft, tests_query)
 	assert(test_query, "dap-go error: could not parse test query")
 
 	for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row) do
@@ -59,11 +57,11 @@ function M.closest_test()
 		for id, node in pairs(match) do
 			local capture = test_query.captures[id]
 			if capture == "mod" then
-				local name = tsquery.get_node_text(node, 0)
+				local name = vim.treesitter.get_node_text(node, 0)
 				test_match.modifier = name
 			end
 			if capture == "fname" then
-				test_match.function_name = tsquery.get_node_text(node, 0)
+				test_match.function_name = vim.treesitter.get_node_text(node, 0)
 			end
 		end
 		table.insert(Debug_test_tree, test_match)

--- a/lua/dap-kotlin/util.lua
+++ b/lua/dap-kotlin/util.lua
@@ -2,43 +2,20 @@ local M = {}
 
 local path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"
 
+---Joins given strings together using system's path separator
+---@vararg string path segments to join together
+---@return string joined path
 function M.path_join(...)
     return table.concat(vim.tbl_flatten({ ... }), path_sep)
 end
 
-local function mysplit(inputstr, sep)
-    if sep == nil then
-        sep = "%s"
-    end
-    local t = {}
-    for str in string.gmatch(inputstr, "([^" .. sep .. "]+)") do
-        table.insert(t, str)
-    end
-    return t
-end
-
-local function indexOf(array, value)
-    for i, v in ipairs(array) do
-        if v == value then
-            return i
-        end
-    end
-    return nil
-end
-
 function M.get_package()
-    local x = vim.fn.fnamemodify(vim.fn.expand("%"), ":p:h")
-    local pathTable = mysplit(x, "/")
-
-    local cutof = indexOf(pathTable, "kotlin")
-    local size1 = 0
-    for _ in pairs(pathTable) do
-        size1 = size1 + 1
-    end
-    for i = cutof, 1, -1 do
-        table.remove(pathTable, 1)
-    end
-
-    return table.concat(pathTable, ".")
+    local file_path = vim.fn.fnamemodify(vim.fn.expand("%"), ":p:h")
+    local sub_path = string.match(
+        file_path,
+        "src" .. path_sep .. "[^%s]+" .. path_sep .. "kotlin" .. path_sep .. "(.*)"
+    )
+    return (sub_path:gsub("%/", "."))
 end
+
 return M


### PR DESCRIPTION
Hi,

I tried to use this plugin, but it was crashing with Neovim 0.10.2, I made it working (at least basic functionalities do work)

This PR:
- Fixes deprecated and removed APIs (treesitter)
- Makes resolving of the package name a bit more stable (instead of looking for kotlin, look for src/.*/kotlin, as kotlin could be anywhere in the absolute path, not necessarily being a part of a source set)